### PR TITLE
Bugfix to Linux build

### DIFF
--- a/LabelDemux/CMakeLists.txt
+++ b/LabelDemux/CMakeLists.txt
@@ -12,6 +12,7 @@ set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
 if (WIN32)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /D_USRDLL /D_WINDLL")
     set(CMAKE_INSTALL_LIBDIR $ENV{APPDATA})
+    set(WS "wsock32 ws2_32")
 endif()
 
 if (CMAKE_VS_PLATFORM_NAME)
@@ -29,7 +30,7 @@ file(GLOB SRC_LIST
     *.h
     *.cpp)
 add_library(LabelDemux SHARED ${SRC_LIST})
-target_link_libraries(LabelDemux PRIVATE lcss::libmp2t wsock32 ws2_32)
+target_link_libraries(LabelDemux PRIVATE lcss::libmp2t ${WS})
 
 generate_export_header(LabelDemux
     EXPORT_FILE_NAME "${CMAKE_CURRENT_SOURCE_DIR}/labeldemux_export.h")


### PR DESCRIPTION
Looks like previous commit links windows libs by default which breaks Linux build, so moved them behind WIN32 flag.
# Ubuntu 22.04
:~/ConfLabelReader$ cmake --build .
[  9%] Building CXX object exi2xml/CMakeFiles/exi2xml.dir/XmlWriter.cpp.o
[ 18%] Linking CXX static library libexi2xml.a
[ 18%] Built target exi2xml
[ 27%] Building CXX object LabelDemux/CMakeFiles/LabelDemux.dir/AccessUnit.cpp.o
[ 36%] Building CXX object LabelDemux/CMakeFiles/LabelDemux.dir/LabelDemux.cpp.o
[ 45%] Building CXX object LabelDemux/CMakeFiles/LabelDemux.dir/LabelDemuxImpl.cpp.o
[ 54%] Building CXX object LabelDemux/CMakeFiles/LabelDemux.dir/Pid2TypeMap.cpp.o
[ 63%] Building CXX object LabelDemux/CMakeFiles/LabelDemux.dir/dllmain.cpp.o
[ 72%] Building CXX object LabelDemux/CMakeFiles/LabelDemux.dir/pch.cpp.o
[ 81%] Linking CXX shared library libLabelDemux.so
/usr/bin/ld: cannot find -lwsock32: No such file or directory
/usr/bin/ld: cannot find -lws2_32: No such file or directory
collect2: error: ld returned 1 exit status
gmake[2]: *** [LabelDemux/CMakeFiles/LabelDemux.dir/build.make:178: LabelDemux/libLabelDemux.so] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:161: LabelDemux/CMakeFiles/LabelDemux.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2