### PR TITLE
Fix typedef conflict when building inside latest ubuntu docker container

### DIFF
--- a/LabelDemux/LabelDemuxTypes.h
+++ b/LabelDemux/LabelDemuxTypes.h
@@ -1,6 +1,15 @@
 #pragma once
 
+#include <cstdint>
+
+#ifdef UINT64_MAX
+typedef uint8_t BYTE;
+typedef uint16_t UINT16;
+typedef uint32_t UINT32;
+typedef uint64_t UINT64;
+#else
 typedef unsigned char BYTE;
 typedef unsigned short UINT16;
 typedef unsigned int UINT32;
 typedef unsigned long long UINT64;
+#endif


### PR DESCRIPTION
1.083 [ 18%] Building CXX object LabelDemux/CMakeFiles/LabelDemux.dir/LabelDemux.cpp.o
1.313 In file included from /usr/local/include/tsadptfd.h:4,
1.313                  from /usr/local/include/libmp2t.h:3,
1.313                  from /ConfLabelReader/LabelDemux/LabelDemuxImpl.h:5,
1.313                  from /ConfLabelReader/LabelDemux/LabelDemux.cpp:7:
1.313 /usr/local/include/tstype.h:8:18: error: conflicting declaration 'typedef uint64_t UINT64'
1.313     8 | typedef uint64_t UINT64;
1.313       |                  ^~~~~~
1.315 In file included from /ConfLabelReader/LabelDemux/LabelDemux.h:3,
1.315                  from /ConfLabelReader/LabelDemux/LabelDemux.cpp:5:
1.315 /ConfLabelReader/LabelDemux/LabelDemuxTypes.h:6:28: note: previous declaration as 'typedef long long unsigned int UINT64'
1.315     6 | typedef unsigned long long UINT64;
1.315       |                            ^~~~~~
1.554 gmake[2]: *** [LabelDemux/CMakeFiles/LabelDemux.dir/build.make:90: LabelDemux/CMakeFiles/LabelDemux.dir/LabelDemux.cpp.o] Error 1