### PR TITLE
Modern CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,6 @@ project (ConfLabelReader
 
 include(GNUInstallDirs)
 
-find_package(exip CONFIG REQUIRED)
-
 # Include sub-projects.
 add_subdirectory (LabelDemux)
 add_subdirectory (exi2xml)
@@ -21,41 +19,37 @@ add_executable(ConfLabelReader)
 
 target_sources(ConfLabelReader PRIVATE src/main.cpp)
 
-list(APPEND EXTRA_LIBS LabelDemux exi2xml exip)
-
-target_link_libraries(ConfLabelReader PRIVATE ${EXTRA_LIBS})
+target_link_libraries(ConfLabelReader PRIVATE LabelDemux exi2xml)
 
 install(TARGETS ConfLabelReader)
 
 # Test Cases
 enable_testing()
 
-message("Working dir: ${CMAKE_CURRENT_BINARY_DIR}")
-
 add_test(NAME ReadN
 	COMMAND ConfLabelReader -i${PROJECT_SOURCE_DIR}/Sample/foreman_cif_klv_4774.ts -n5 -olabels.txt
 	WORKING_DIRECTORY ${UNIT_TEST_BIN_OUTPUT_DIR}
-	)
+)
 set_tests_properties(ReadN
 	PROPERTIES PASS_REGULAR_EXPRESSION "Labels read: 5
 TS Packets read: 1764"
-	)
+)
 
 add_test(NAME ReadAll
 	COMMAND ConfLabelReader -i${PROJECT_SOURCE_DIR}/Sample/foreman_cif_klv_4774.ts -olabels.txt
 	WORKING_DIRECTORY ${UNIT_TEST_BIN_OUTPUT_DIR}
-	)
+)
 set_tests_properties(ReadAll
 	PROPERTIES PASS_REGULAR_EXPRESSION "Labels read: 11
 TS Packets read: 4258"
-	)
+)
 
 add_test(NAME NoLabel
 	COMMAND ConfLabelReader -i${PROJECT_SOURCE_DIR}/Sample/foreman_cif_klv.ts -olabels.txt
 	WORKING_DIRECTORY ${UNIT_TEST_BIN_OUTPUT_DIR}
-	)
+)
 set_tests_properties(NoLabel
 	PROPERTIES PASS_REGULAR_EXPRESSION "No label in motion imagery file, foreman_cif_klv.ts
 Labels read: 0
 TS Packets read: 49"
-	)
+)

--- a/LabelDemux/CMakeLists.txt
+++ b/LabelDemux/CMakeLists.txt
@@ -11,9 +11,7 @@ endif()
 
 # set the postfix "d" for the resulting .so or .dll files when building the
 # library in debug mode
-set(CMAKE_DEBUG_POSTFIX
-    d
-)
+set(CMAKE_DEBUG_POSTFIX d)
 
 find_package(mp2tp 1 CONFIG REQUIRED)
 
@@ -22,32 +20,40 @@ add_library(LabelDemux SHARED)
 # set properties for the target. VERSION set the library version to the project
 # version * SOVERSION set the compatibility  version for the library to the
 # major number of the version
-set_target_properties(
-    LabelDemux
-    PROPERTIES VERSION ${PROJECT_VERSION}
-               SOVERSION ${PROJECT_VERSION_MAJOR}
+set_target_properties( LabelDemux
+  PROPERTIES 
+    VERSION ${PROJECT_VERSION}
+    SOVERSION ${PROJECT_VERSION_MAJOR}
 )
 
-file(GLOB SRC_LIST src/*.cpp)
-
-target_sources(LabelDemux PRIVATE ${SRC_LIST})
+target_sources(LabelDemux 
+  PRIVATE
+    src/AccessUnit.cpp
+    src/AccessUnit.h
+    src/LabelDemux.cpp
+    src/LabelDemuxImpl.cpp
+    src/LabelDemuxImpl.h
+    src/pch.cpp
+    src/Pid2TypeMap.cpp
+    src/Pid2TypeMap.h
+    include/LabelDemux/framework.h
+    include/LabelDemux/LabelDemux.h
+    include/LabelDemux/LabelDemuxTypes.h
+    include/LabelDemux/pch.h
+)
 
 # define the C++ standard needed to compile this library and make it visible to
 # dependers
-target_compile_features(
-    LabelDemux
-    PUBLIC cxx_std_14
-)
+target_compile_features( LabelDemux PUBLIC cxx_std_14)
+
+target_link_libraries(LabelDemux PRIVATE lcss::mp2tp)
 
 if (WIN32)
-    set(WS wsock32 ws2_32)
+    target_link_libraries(LabelDemux PRIVATE wsock32 ws2_32)
 endif()
 
-target_link_libraries(LabelDemux PRIVATE lcss::mp2tp ${WS})
-
 # set the include directories
-target_include_directories(
-    LabelDemux
+target_include_directories( LabelDemux
     PRIVATE src/LabelDemux
     PUBLIC include
 )

--- a/README.md
+++ b/README.md
@@ -6,19 +6,19 @@ Imagery stream (MPEG-2 Transport Stream).
 The project is composed of multiple sub-projects, which are as follows:
 
 * __LabelDemux__: A library that demultiplexes the MPEG-2 transport stream, and 
-extracts the label.  The label is EXI encoded, and has to be transcoded to XML
-if it needs to be human readable.  The `exi2xml` library can be used to transcode
+extracts the label.  The label is EXI encoded and has to be transcoded to XML
+if it needs to be human-readable.  The `exi2xml` library can be used to transcode
 the label to XML.  `LabelDemux` library has an external dependency on 
-[mp2tp library](https://github.com/jimcavoy/mp2tp), which is needed to be build and install.
+[mp2tp library](https://github.com/jimcavoy/mp2tp), which is needed to be built and installed.
 
-* __exi2xml__: A library to transcode EXI encoded labels to XML text format.  The library is
-generic, and can decode EXI labels based on different XML schemas.  This library has 
+* __exi2xml__: A library to transcode EXI-encoded labels to XML text format.  The library is
+generic and can decode EXI labels based on different XML schemas.  This library has 
 an external dependency on [EXIP library](https://github.com/rwl/exip).  See Readme.md in the 
 exipCMake folder how to build and install `exip` library.
 
 * __ConfLabelReader__: A tool that reads a MPEG-2 transport stream from a file or standard input stream (stdin), and
-prints Confidentiality Metadata Label in XML to a file or standard output stream (stdout).  The tool  
+prints a Confidentiality Metadata Label in XML to a file or standard output stream (stdout).  The tool  
 depends on `exi2xml` and `LabelDemux` libraries.
 
-The project is cross-platform, and can be build and run on both Windows and
+The project is cross-platform and can be built and run on both Windows and
 Linux platforms.


### PR DESCRIPTION
As recommended in modern cmake practices, avoid custom variables in project commands. So no file(GLOB) commands.
In the root project, remove find_package for exip because subdirectory projects do it. 
Minor edits to Readme.md file.