### PR TITLE
Enable position independent code

### DIFF
--- a/exipCMake/CMakeLists.txt
+++ b/exipCMake/CMakeLists.txt
@@ -48,6 +48,8 @@ target_include_directories(exip
           "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
           "$<INSTALL_INTERFACE:include>"
           )
+          
+set_target_properties(exip PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 # install the target and create export-set
 install(TARGETS exip 


### PR DESCRIPTION
Enable position independent code when building exip library.