### PR TITLE
Handle Bad PAT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required (VERSION 3.21)
 
 project (ConfLabelReader
-	VERSION 1.2.0
+	VERSION 1.2.1
 	DESCRIPTION "A program that parses STANAG 4609 Motion Imagery Stream for STANAG 4774 Confidentiality Metadata Labels."
 	LANGUAGES C CXX
 )

--- a/LabelDemux/CMakeLists.txt
+++ b/LabelDemux/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required (VERSION 3.21)
 project(LabelDemux
-    VERSION 1.2.0
+    VERSION 1.2.1
     DESCRIPTION "Confidentiality Metadata Label Demuxer Library"
     LANGUAGES C CXX
 )

--- a/LabelDemux/src/LabelDemuxImpl.cpp
+++ b/LabelDemux/src/LabelDemuxImpl.cpp
@@ -88,9 +88,11 @@ void LabelDemuxImpl::executeCallback()
 void LabelDemuxImpl::processStartPayload(const lcss::TransportPacket& pckt)
 {
     const BYTE* data = pckt.getData();
-    if (pckt.PID() == 0 && _pat.size() == 0) // Program Association Table
+    if (pckt.PID() == 0) // Program Association Table
     {
-        _pat.parse(data);
+        lcss::ProgramAssociationTable pat;
+        pat.parse(data);
+        _pat = pat;
     }
     else if (_pat.find(pckt.PID()) != _pat.end())
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,7 @@ void printExiLabel(std::ostream& ostrm, const BYTE* label, size_t len);
 bool canStop(int num, int limit);
 std::string getFilename(std::string& path);
 std::shared_ptr<std::istream> createInput(std::string filepath);
+std::shared_ptr<std::ostream> createOutput(std::string filepath);
 void Banner();
 
 // main
@@ -109,7 +110,7 @@ int main(int argc, char* argv[])
     try
     {
         shared_ptr<istream> input = createInput(ifile);
-        ofstream oStream(ofile);
+        shared_ptr<ostream> output = createOutput(ofile);
 
         while (input->good())
         {
@@ -129,13 +130,13 @@ int main(int argc, char* argv[])
 
                     if (encoding == "$EXI")
                     {
-                        printExiLabel(oStream, label, len);
+                        printExiLabel(*output, label, len);
                     }
                     else if (encoding == "$XML")
                     {
                         std::string xml;
                         std::copy(label, label + len, std::back_inserter(xml));
-                        oStream << xml << endl;
+                        *output << xml << endl;
                     }
                     labelsRead++;
                 }
@@ -230,8 +231,30 @@ std::shared_ptr<std::istream> createInput(std::string filepath)
     return input;
 }
 
+std::shared_ptr<std::ostream> createOutput(std::string filepath)
+{
+    std::shared_ptr<std::ostream> output;
+
+    if (filepath.empty())
+    {
+        output.reset(&std::cout, [](...) {});
+    }
+    else // read the file
+    {
+        std::ofstream* tsfile = new std::ofstream(filepath);
+        if (!tsfile->is_open())
+        {
+            std::string err("Fail to open file: ");
+            err += getFilename(filepath);
+            throw std::ios_base::failure(err);
+        }
+        output.reset(tsfile);
+    }
+    return output;
+}
+
 void Banner()
 {
-    std::cerr << "ConfLabelReader: Confidentiality Label Reader Application v1.2.0" << std::endl;
+    std::cerr << "ConfLabelReader: Confidentiality Label Reader Application v1.2.1" << std::endl;
     std::cerr << "Copyright (c) 2025 ThetaStream Consulting, jimcavoy@thetastream.com" << std::endl << std::endl;
 }


### PR DESCRIPTION
In LabelDemux, update the PAT instance every time it reads one in the transport stream.  Before, the LabelDemux would only read the first one.  Therefore, if the first PAT was malformed, the LabelDemux would fail to find the PMT.

Bump version number to 1.2.1.

In main, if no output file is specified, ensure to prints the labels out to console.